### PR TITLE
fix is pytest fixture

### DIFF
--- a/tests/input/redefined-outer-name/direct_import.py
+++ b/tests/input/redefined-outer-name/direct_import.py
@@ -1,0 +1,28 @@
+from pytest import fixture
+
+
+@fixture
+def simple_decorator():
+    """the fixture using the decorator without executing it"""
+
+
+def test_simple_fixture(simple_decorator):
+    assert True
+
+
+@fixture()
+def un_configured_decorated():
+    """the decorated is called without argument, like scope"""
+
+
+def test_un_configured_decorated(un_configured_decorated):
+    assert True
+
+
+@fixture(scope="function")
+def configured_decorated():
+    """the decorated is called with argument, like scope"""
+
+
+def test_un_configured_decorated(configured_decorated):
+    assert True

--- a/tests/test_redefined_outer_name.py
+++ b/tests/test_redefined_outer_name.py
@@ -30,8 +30,8 @@ class TestRedefinedOuterName(BasePytestTester):
         self.run_linter(enable_plugin)
         self.verify_messages(2)
 
-    @pytest.mark.parametrize('enable_plugin', [True, False])
+    @pytest.mark.parametrize("enable_plugin", [True, False])
     def test_direct_import(self, enable_plugin):
-        """the fixture method is directly imported """
+        """the fixture method is directly imported"""
         self.run_linter(enable_plugin)
         self.verify_messages(0 if enable_plugin else 3)

--- a/tests/test_redefined_outer_name.py
+++ b/tests/test_redefined_outer_name.py
@@ -29,3 +29,9 @@ class TestRedefinedOuterName(BasePytestTester):
     def test_args_and_kwargs(self, enable_plugin):
         self.run_linter(enable_plugin)
         self.verify_messages(2)
+
+    @pytest.mark.parametrize('enable_plugin', [True, False])
+    def test_direct_import(self, enable_plugin):
+        """the fixture method is directly imported """
+        self.run_linter(enable_plugin)
+        self.verify_messages(0 if enable_plugin else 3)


### PR DESCRIPTION
currently, both fixture in this example are flagged has not fixtures
```python
from pytest import fixture

@fixture
def my_fixture(): pass

@fixture(name="foo")
def my_fixture_2(): pass
```
This is due to the different semantics in astroid when using `import pytest` or `from pytest import ...`
