### PR TITLE
Add a release job to publish on pypi on github tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  release:
+    types:
+      - published
+
+env:
+  DEFAULT_PYTHON: "3.11"
+
+permissions:
+  contents: read
+
+jobs:
+  release-pypi:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: PyPI
+      url: https://pypi.org/project/pylint-pytest/
+    steps:
+      - name: Check out code from Github
+        uses: actions/checkout@v4.1.0
+      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+        id: python
+        uses: actions/setup-python@v4.7.1
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          check-latest: true
+      - name: Install requirements
+        run: |
+          # Remove dist, build, and pylint.egg-info
+          # when building locally for testing!
+          python -m pip install twine build
+      - name: Build distributions
+        run: |
+          python -m build
+      - name: Upload to PyPI
+        if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
+        env:
+          TWINE_REPOSITORY: pypi
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          twine upload --verbose dist/*


### PR DESCRIPTION
Similar to what is done in pylint (we could test that with alphas first, when releasing the last version only compatible with pylint 2).