### PR TITLE
Use ruff instead of flake8 pyupgrade autoflake and isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,26 +8,12 @@ repos:
       - id: pretty-format-json
         args: [ "--no-sort-keys", "--autofix", "--indent=4" ]
         exclude: ^.vscode/
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.292
     hooks:
-      - id: pyupgrade
-        args:
-          - --py36-plus
-  - repo: https://github.com/PyCQA/autoflake
-    rev: v2.2.1
-    hooks:
-      - id: autoflake
-  # - repo: https://github.com/astral-sh/ruff-pre-commit
-  #   rev: v0.0.292
-  #   hooks:
-  #     - id: ruff
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        args:
-          - --filter-files
+      - id: ruff
+        args: ["--fix"]
+        exclude: "tests/input/"
   - repo: https://github.com/psf/black
     rev: 23.9.1
     hooks:
@@ -37,7 +23,7 @@ repos:
     hooks:
       - id: blacken-docs
         additional_dependencies:
-          - black==22.6.0
+          - black==23.9.1
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:
@@ -52,24 +38,6 @@ repos:
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
       - id: text-unicode-replacement-char
-  # - repo: https://github.com/pycqa/flake8
-  #   rev: 5.0.4
-  #   hooks:
-  #     - id: flake8
-  #       additional_dependencies:
-  #         - flake8-bandit
-  #         - flake8-bugbear
-  #         - flake8-class-attributes-order
-  #         - flake8-comprehensions
-  #         # - flake8-docstrings  # it is a mess to clean up; let's only warn user's IDEs instead.
-  #         - flake8-future-annotations
-  #         - flake8-noqa
-  #         - flake8-print
-  #         - flake8-pyproject
-  #         - flake8-pytest-style
-  #         - flake8-type-checking
-  #         - flake8-variables-names
-  #         - pep8-naming
   # - repo: https://github.com/pre-commit/mirrors-mypy
   #   rev: v1.6.0
   #   hooks:

--- a/pylint_pytest/checkers/class_attr_loader.py
+++ b/pylint_pytest/checkers/class_attr_loader.py
@@ -49,6 +49,6 @@ class ClassAttrLoader(BasePytestChecker):
 
                 # hack class locals
                 self.class_node.locals[node.attrname] = [assign_node.value]
-            except:  # pylint: disable=bare-except
+            except Exception:  # pylint: disable=broad-except
                 # cannot find valid assign expr, skipping the entire attribute
                 pass

--- a/pylint_pytest/checkers/fixture.py
+++ b/pylint_pytest/checkers/fixture.py
@@ -62,7 +62,8 @@ class FixtureChecker(BasePytestChecker):
         "F6401": (
             (
                 "pylint-pytest plugin cannot enumerate and collect pytest fixtures. "
-                "Please run `pytest --fixtures --collect-only path/to/current/module.py` and resolve any potential syntax error or package dependency issues"
+                "Please run `pytest --fixtures --collect-only path/to/current/module.py`"
+                " and resolve any potential syntax error or package dependency issues"
             ),
             "cannot-enumerate-pytest-fixtures",
             "Used when pylint-pytest has been unable to enumerate and collect pytest fixtures.",

--- a/pylint_pytest/utils.py
+++ b/pylint_pytest/utils.py
@@ -115,6 +115,6 @@ def _is_same_module(fixtures, import_node, fixture_name):
                     ).file
                 ):
                     return True
-    except:  # pylint: disable=bare-except
+    except Exception:  # pylint: disable=broad-except
         pass
     return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,6 @@
 [tool.black]
 line-length = 100
 
-[tool.isort]
-profile = "black"
-
 [tool.coverage]
 run.branch = true
 run.data_file = "test_artifacts/.coverage"
@@ -37,15 +34,6 @@ report.exclude_lines = [
 paths.source = [
     "pylint_pytest/",
 ]
-
-[tool.flake8]
-# Black compatible settings
-max-line-length = 100
-extend-ignore = ["E203"]
-extend-select = ["TC", "TC1", "B902", "B903"]
-
-noqa-require-code = true
-noqa-include-name = true
 
 [tool.mypy]
 python_version = "3.7"
@@ -93,7 +81,7 @@ select = [
     "W",  # pycodestyle
     "B",  # bugbear
     "I",  # isort
-    "RUF", # ruff
+#    "RUF", # ruff
     "UP", # pyupgrade
 ]
 

--- a/tests/test_cannot_enumerate_fixtures.py
+++ b/tests/test_cannot_enumerate_fixtures.py
@@ -1,6 +1,5 @@
 import pytest
 from base_tester import BasePytestTester
-from pylint.checkers.variables import VariablesChecker
 
 from pylint_pytest.checkers.fixture import FixtureChecker
 


### PR DESCRIPTION
Follow-up to #4 (can wait a new release compatible with pylint 3.0)