### PR TITLE
Activate mypy in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,10 +41,11 @@ repos:
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
       - id: text-unicode-replacement-char
-  # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: v1.6.0
-  #   hooks:
-  #     - id: mypy
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.6.0
+    hooks:
+       - id: mypy
+         exclude: "tests/input/"
   - repo: local
     hooks:
       - id: pylint

--- a/pylint_pytest/checkers/class_attr_loader.py
+++ b/pylint_pytest/checkers/class_attr_loader.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+from typing import Optional, Set
 
 from astroid import Assign, Attribute, ClassDef, Name
 from pylint.interfaces import IAstroidChecker
@@ -12,8 +12,8 @@ class ClassAttrLoader(BasePytestChecker):
     msgs = {"E6400": ("", "pytest-class-attr-loader", "")}
 
     in_setup = False
-    request_cls: set[str] = set()
-    class_node: ClassDef | None = None
+    request_cls: Set[str] = set()
+    class_node: Optional[ClassDef] = None
 
     def visit_functiondef(self, node):
         """determine if a method is a class setup method"""

--- a/pylint_pytest/checkers/class_attr_loader.py
+++ b/pylint_pytest/checkers/class_attr_loader.py
@@ -1,4 +1,6 @@
-import astroid
+from __future__ import annotations
+
+from astroid import Assign, Attribute, ClassDef, Name
 from pylint.interfaces import IAstroidChecker
 
 from ..utils import _can_use_fixture, _is_class_autouse_fixture
@@ -10,8 +12,8 @@ class ClassAttrLoader(BasePytestChecker):
     msgs = {"E6400": ("", "pytest-class-attr-loader", "")}
 
     in_setup = False
-    request_cls = set()
-    class_node = None
+    request_cls: set[str] = set()
+    class_node: ClassDef | None = None
 
     def visit_functiondef(self, node):
         """determine if a method is a class setup method"""
@@ -23,12 +25,13 @@ class ClassAttrLoader(BasePytestChecker):
             self.in_setup = True
             self.class_node = node.parent
 
-    def visit_assign(self, node):
+    def visit_assign(self, node: Assign):
         """store the aliases for `cls`"""
         if (
             self.in_setup
-            and isinstance(node.value, astroid.Attribute)
+            and isinstance(node.value, Attribute)
             and node.value.attrname == "cls"
+            and isinstance(node.value.expr, Name)
             and node.value.expr.name == "request"
         ):
             # storing the aliases for cls from request.cls
@@ -37,14 +40,15 @@ class ClassAttrLoader(BasePytestChecker):
     def visit_assignattr(self, node):
         if (
             self.in_setup
-            and isinstance(node.expr, astroid.Name)
+            and isinstance(node.expr, Name)
             and node.expr.name in self.request_cls
+            and self.class_node is not None
             and node.attrname not in self.class_node.locals
         ):
             try:
                 # find Assign node which contains the source "value"
                 assign_node = node
-                while not isinstance(assign_node, astroid.Assign):
+                while not isinstance(assign_node, Assign):
                     assign_node = assign_node.parent
 
                 # hack class locals

--- a/pylint_pytest/checkers/fixture.py
+++ b/pylint_pytest/checkers/fixture.py
@@ -1,9 +1,8 @@
-from __future__ import annotations
-
 import fnmatch
 import os
 import sys
 from pathlib import Path
+from typing import Set, Tuple
 
 import astroid
 import pylint
@@ -22,7 +21,7 @@ from . import BasePytestChecker
 from .types import FixtureDict, replacement_add_message
 
 # TODO: support pytest python_files configuration
-FILE_NAME_PATTERNS: tuple[str, ...] = ("test_*.py", "*_test.py")
+FILE_NAME_PATTERNS: Tuple[str, ...] = ("test_*.py", "*_test.py")
 ARGUMENT_ARE_KEYWORD_ONLY = (
     "https://docs.pytest.org/en/stable/deprecations.html#pytest-fixture-arguments-are-keyword-only"
 )
@@ -31,7 +30,7 @@ ARGUMENT_ARE_KEYWORD_ONLY = (
 class FixtureCollector:
     # Same as ``_pytest.fixtures.FixtureManager._arg2fixturedefs``.
     fixtures: FixtureDict = {}
-    errors: set[pytest.CollectReport] = set()
+    errors: Set[pytest.CollectReport] = set()
 
     def pytest_sessionfinish(self, session):
         # pylint: disable=protected-access
@@ -80,9 +79,9 @@ class FixtureChecker(BasePytestChecker):
     # Store all fixtures discovered by pytest session
     _pytest_fixtures: FixtureDict = {}
     # Stores all used function arguments
-    _invoked_with_func_args: set[str] = set()
+    _invoked_with_func_args: Set[str] = set()
     # Stores all invoked fixtures through @pytest.mark.usefixture(...)
-    _invoked_with_usefixtures: set[str] = set()
+    _invoked_with_usefixtures: Set[str] = set()
     _original_add_message = replacement_add_message
 
     def open(self):

--- a/pylint_pytest/checkers/types.py
+++ b/pylint_pytest/checkers/types.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import sys
+from pprint import pprint
+from typing import Any, Dict, List
+
+from _pytest.fixtures import FixtureDef
+
+FixtureDict = Dict[str, List[FixtureDef[Any]]]
+
+
+def replacement_add_message(*args, **kwargs):
+    print("Called un-initialized _original_add_message with:", file=sys.stderr)
+    pprint(args, sys.stderr)
+    pprint(kwargs, sys.stderr)

--- a/pylint_pytest/checkers/types.py
+++ b/pylint_pytest/checkers/types.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import sys
 from pprint import pprint
 from typing import Any, Dict, List

--- a/pylint_pytest/utils.py
+++ b/pylint_pytest/utils.py
@@ -108,12 +108,11 @@ def _is_same_module(fixtures, import_node, fixture_name):
     try:
         for fixture in fixtures[fixture_name]:
             for import_from in import_node.root().globals[fixture_name]:
-                if (
-                    inspect.getmodule(fixture.func).__file__
-                    == import_from.parent.import_module(
-                        import_from.modname, False, import_from.level
-                    ).file
-                ):
+                module = inspect.getmodule(fixture.func)
+                parent_import = import_from.parent.import_module(
+                    import_from.modname, False, import_from.level
+                )
+                if module is not None and module.__file__ == parent_import.file:
                     return True
     except Exception:  # pylint: disable=broad-except
         pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ ignore = [
     "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
 ]
 
+# py36, but ruff does not support it :/
+target-version = "py37"
+
 [tool.ruff.pydocstyle]
 convention = "google"
 
@@ -109,6 +112,8 @@ convention = "google"
 ]
 
 [tool.pylint]
+
+py-version = "3.6"
 
 ignore-paths="tests/input" # Ignore test inputs
 

--- a/tests/base_tester.py
+++ b/tests/base_tester.py
@@ -1,10 +1,8 @@
-from __future__ import annotations
-
 import os
 import sys
 from abc import ABC
 from pprint import pprint
-from typing import Any
+from typing import Any, Dict, List
 
 import astroid
 from pylint.testutils import MessageTest, UnittestLinter
@@ -25,10 +23,10 @@ pylint_pytest.checkers.fixture.FILE_NAME_PATTERNS = ("*",)
 
 class BasePytestTester(ABC):
     CHECKER_CLASS = BaseChecker
-    IMPACTED_CHECKER_CLASSES: list[BaseChecker] = []
+    IMPACTED_CHECKER_CLASSES: List[BaseChecker] = []
     MSG_ID: str
-    msgs: list[MessageTest] = []
-    CONFIG: dict[str, Any] = {}
+    msgs: List[MessageTest] = []
+    CONFIG: Dict[str, Any] = {}
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)

--- a/tests/base_tester_test.py
+++ b/tests/base_tester_test.py
@@ -20,7 +20,7 @@ def test_init_subclass_no_msg_id():
             pass
 
 
-@pytest.mark.parametrize("msg_id", [123, None, ""], ids=lambda msg_id: f"{msg_id=}")
+@pytest.mark.parametrize("msg_id", [123, None, ""], ids=lambda x: f"msg_id={x}")
 def test_init_subclass_invalid_msg_id_type(msg_id):
     with pytest.raises(TypeError):
 

--- a/tests/base_tester_test.py
+++ b/tests/base_tester_test.py
@@ -1,0 +1,28 @@
+import pytest
+from base_tester import BasePytestTester
+
+# pylint: disable=unused-variable
+
+
+def test_init_subclass_valid_msg_id():
+    some_string = "some_string"
+
+    class ValidSubclass(BasePytestTester):
+        MSG_ID = some_string
+
+    assert ValidSubclass.MSG_ID == some_string
+
+
+def test_init_subclass_no_msg_id():
+    with pytest.raises(TypeError):
+
+        class NoMsgIDSubclass(BasePytestTester):
+            pass
+
+
+@pytest.mark.parametrize("msg_id", [123, None, ""], ids=lambda msg_id: f"{msg_id=}")
+def test_init_subclass_invalid_msg_id_type(msg_id):
+    with pytest.raises(TypeError):
+
+        class Subclass(BasePytestTester):
+            MSG_ID = msg_id

--- a/tests/test_pytest_yield_fixture.py
+++ b/tests/test_pytest_yield_fixture.py
@@ -5,7 +5,6 @@ from pylint_pytest.checkers.fixture import FixtureChecker
 
 class TestDeprecatedPytestYieldFixture(BasePytestTester):
     CHECKER_CLASS = FixtureChecker
-    IMPACTED_CHECKER_CLASSES = []
     MSG_ID = "deprecated-pytest-yield-fixture"
 
     def test_smoke(self):


### PR DESCRIPTION
Drafting because this will also be easier if we can do ``from __future__ import annotations`` after python 3.6 / 3.7 is dropped.