### PR TITLE
Improvements for `.github/workflows/run-tests.yaml`

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -59,5 +63,13 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: ${{ matrix.os }},${{ matrix.python-version }}
         fail_ci_if_error: true
         files: test_artifacts/cobertura.xml
+
+    - name: Create artifacts
+      uses: actions/upload-artifact@v3
+      if: ${{ !cancelled() }}
+      with:
+        name: test-artifacts_${{ matrix.os }}_${{ matrix.python-version }}
+        path: test_artifacts/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ![PyPI - Downloads](https://img.shields.io/pypi/dd/pylint-pytest)
 ![PyPI - Version](https://img.shields.io/pypi/v/pylint-pytest)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pylint-pytest)
+[![codecov](https://codecov.io/gh/pylint-dev/pylint-pytest/graph/badge.svg?token=NhZDLKmomd)](https://codecov.io/gh/pylint-dev/pylint-pytest)
 
 A Pylint plugin to suppress pytest-related false positives.
 


### PR DESCRIPTION
* Configure action `concurrency:`
* Use `codecov/codecov-action@v3` flags (might ... help codecov, somehow)
* Upload testing artifacts
* Add the Codecov badge in the README.md

Signed-off-by: Stavros Ntentos <133706+stdedos@users.noreply.github.com>