### PR TITLE
🐛 Ignore collection failures in non-tests

### DIFF
--- a/pylint_pytest/checkers/fixture.py
+++ b/pylint_pytest/checkers/fixture.py
@@ -68,8 +68,8 @@ class FixtureChecker(BasePytestChecker):
         "F6401": (
             (
                 "pylint-pytest plugin cannot enumerate and collect pytest fixtures. "
-                "Please run `pytest --fixtures --collect-only path/to/current/module.py`"
-                " and resolve any potential syntax error or package dependency issues"
+                "Please run `pytest --fixtures --collect-only %s` and resolve "
+                "any potential syntax error or package dependency issues"
             ),
             "cannot-enumerate-pytest-fixtures",
             "Used when pylint-pytest has been unable to enumerate and collect pytest fixtures.",
@@ -143,8 +143,23 @@ class FixtureChecker(BasePytestChecker):
 
                 FixtureChecker._pytest_fixtures = fixture_collector.fixtures
 
-                if (ret != pytest.ExitCode.OK or fixture_collector.errors) and is_test_module:
-                    self.add_message("cannot-enumerate-pytest-fixtures", node=node)
+                legitimate_failure_paths = set(
+                    collection_report.nodeid
+                    for collection_report in fixture_collector.errors
+                    if any(
+                        fnmatch.fnmatch(
+                            Path(collection_report.nodeid).name,
+                            pattern,
+                        )
+                        for pattern in FILE_NAME_PATTERNS
+                    )
+                )
+                if (ret != pytest.ExitCode.OK or legitimate_failure_paths) and is_test_module:
+                    self.add_message(
+                        "cannot-enumerate-pytest-fixtures",
+                        args=" ".join(legitimate_failure_paths | {node.file}),
+                        node=node,
+                    )
         finally:
             # restore output devices
             sys.stdout, sys.stderr = stdout, stderr

--- a/tests/test_cannot_enumerate_fixtures.py
+++ b/tests/test_cannot_enumerate_fixtures.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from base_tester import BasePytestTester
 
@@ -13,7 +15,39 @@ class TestCannotEnumerateFixtures(BasePytestTester):
         self.run_linter(enable_plugin)
         self.verify_messages(1 if enable_plugin else 0)
 
+        if enable_plugin:
+            msg = self.msgs[0]
+
+            # Asserts/Fixes duplicate filenames in output:
+            # https://github.com/reverbc/pylint-pytest/pull/22/files#r698204470
+            filename_arg = msg.args[0]
+            assert len(re.findall(r"\.py", filename_arg)) == 1
+
+            # Asserts that path is relative (usually to the root of the repository).
+            assert filename_arg[0] != "/"
+
+            # Assert `stdout` is non-empty.
+            assert msg.args[1]
+            # Assert `stderr` is empty (pytest runs stably, even though fixture collection fails).
+            assert not msg.args[2]
+
     @pytest.mark.parametrize("enable_plugin", [True, False])
     def test_import_corrupted_module(self, enable_plugin):
         self.run_linter(enable_plugin)
         self.verify_messages(1 if enable_plugin else 0)
+
+        if enable_plugin:
+            msg = self.msgs[0]
+
+            # ... somehow, since `import_corrupted_module.py` imports `no_such_package.py`
+            # both of their names are returned in the message.
+            filename_arg = msg.args[0]
+            assert len(re.findall(r"\.py", filename_arg)) == 2
+
+            # Asserts that paths are relative (usually to the root of the repository).
+            assert not [x for x in filename_arg.split(" ") if x[0] == "/"]
+
+            # Assert `stdout` is non-empty.
+            assert msg.args[1]
+            # Assert `stderr` is empty (pytest runs stably, even though fixture collection fails).
+            assert not msg.args[2]


### PR DESCRIPTION
This change applies the pre-existing patterns to identify if the files with collection problems are tests. It is then used to eliminate the false-positives of F6401 (cannot-enumerate-pytest-fixtures).

As a side effect, this patch also includes precise file paths that may be used to reproduce the problem.

Fixes reverbc#20
Fixes reverbc#21

Signed-off-by: Sviatoslav Sydorenko <wk@sydorenko.org.ua>

_Replayed; Source PR: https://github.com/reverbc/pylint-pytest/pull/22_

Additionally, satisfied the https://github.com/pylint-dev/pylint-pytest's `.pre-commit-config.yaml`

Signed-off-by: Stavros Ntentos <133706+stdedos@users.noreply.github.com>

* Capture and return `stdout` and `stderr` (instead of trashing them)
* Fix the 'duplicate-path' error by `relative`-izing the paths before `union`ing them
* Update tests to test for both conditions

Additionally, fix two `used-before-assignment` pylint issues (`stdout`, `stderr`) 🤪

Signed-off-by: Stavros Ntentos <133706+stdedos@users.noreply.github.com>