### PR TITLE
Fix testing + coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - tests/input/**/*.py

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -41,6 +41,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Slugify GITHUB_REPOSITORY
+      run: echo "GITHUB_REPOSITORY_SLUG=${GITHUB_REPOSITORY////_}" >> $GITHUB_ENV
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -71,5 +74,5 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ !cancelled() }}
       with:
-        name: test-artifacts_${{ matrix.os }}_${{ matrix.python-version }}
+        name: ${{ env.GITHUB_REPOSITORY_SLUG }}_test-artifacts_${{ github.event_name }}_${{ github.event.pull_request.number || github.sha }}_${{ matrix.os }}_py${{ matrix.python-version }}
         path: test_artifacts/

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310,py311,py312
+envlist = py36,py37,py38,py39,py310,py311
 skipsdist = True
 passenv =
     FORCE_COLOR
@@ -9,5 +9,5 @@ deps =
     pytest
     pytest-cov
 commands =
-    pip install --upgrade .
+    pip install --upgrade --editable .
     pytest --cov --cov-append {env:PYTEST_CI_ARGS:} {tty:--color=yes} {posargs:tests}


### PR DESCRIPTION
* Drop `py312` to combat https://github.com/pylint-dev/pylint-pytest/issues/16
* Install `--editable`, so that Python uses the correct source files for coverage
* Ignore `tests/input/**/*.py` from coverage - they are not ran properly
* Again improve on artifact naming

Signed-off-by: Stavros Ntentos <133706+stdedos@users.noreply.github.com>