### PR TITLE
Improve packaging + Release v1.1.3rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ A heartfelt thank you to https://github.com/Pierre-Sassoulas for his invaluable 
 
 - Added an extensive `.pre-commit-config.yaml` file to upkeep the code quality.
   It includes, among others, `black`, `mypy` (in non-strict mode yet), `ruff`, and `pylint`.
+- Added an automated release process
 
 ### Changed
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+prune tests/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
 [aliases]
 test = pytest
-
-[bdist_wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(here, "README.md")) as fin:
 
 setup(
     name="pylint-pytest",
-    version="1.1.3rc0",
+    version="1.1.3rc1",
     author="Stavros Ntentos",
     author_email="133706+stdedos@users.noreply.github.com",
     license="MIT",
@@ -26,7 +26,7 @@ setup(
     description="A Pylint plugin to suppress pytest-related false positives.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    packages=find_packages(exclude=["tests", "sandbox"]),
+    packages=find_packages(exclude=["tests*", "sandbox"]),
     install_requires=[
         "pylint<3",
         "pytest>=4.6",


### PR DESCRIPTION
* Drop `tests/*` both from `sdist` and `wheel`
* Drop `universal` wheel (we don't support Python2)

Signed-off-by: Stavros Ntentos <133706+stdedos@users.noreply.github.com>