### PR TITLE
Drop python 3.6 and 3.7 which are past end of life upstream

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -20,20 +20,11 @@ jobs:
           - windows-latest
           - macos-latest
         python-version:
-          - '3.6'
-          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'
-          # - '3.12'  # FixMe: https://github.com/pylint-dev/pylint-pytest/issues/3
-        # Python 3.6 is not available in `ubuntu-latest`.
-        exclude:
-          - python-version: '3.6'
-            os: ubuntu-latest
-        include:
-          - python-version: '3.6'
-            os: ubuntu-20.04
+#          - '3.12'  # FixMe: https://github.com/pylint-dev/pylint-pytest/issues/3
 
     defaults:
       run:
@@ -68,7 +59,7 @@ jobs:
         env:
           FORCE_COLOR: 1
           PYTEST_CI_ARGS: --cov-report=xml --junitxml=test_artifacts/test_report.xml --color=yes
-        run: tox ${{ matrix.python-version == '3.6' && '--skip-missing-interpreters=true' || '' }}
+        run: tox --skip-missing-interpreters=true
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Removed
+
+- Support for Python 3.6 & 3.7 (#23)
+
 ## [1.1.6] - 2023-11-20
 
 This is a small bugfix release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,6 @@
 # Only a configuration storage, for now
+[tool.aliases]
+test = "pytest"
 
 [tool.black]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ paths.source = [
 ]
 
 [tool.mypy]
-python_version = "3.7"
+python_version = "3.8"
 check_untyped_defs = true
 explicit_package_bases = true
 namespace_packages = true
@@ -91,8 +91,7 @@ ignore = [
     "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
 ]
 
-# py36, but ruff does not support it :/
-target-version = "py37"
+target-version = "py38"
 
 [tool.ruff.pydocstyle]
 convention = "google"
@@ -115,7 +114,7 @@ convention = "google"
 
 [tool.pylint]
 
-py-version = "3.6"
+py-version = "3.8"
 
 ignore-paths="tests/input" # Ignore test inputs
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[aliases]
-test = pytest

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "pylint<3",
         "pytest>=4.6",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
@@ -39,8 +39,6 @@ setup(
         "Topic :: Software Development :: Quality Assurance",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310,py311
+envlist = py38,py39,py310,py311
 skipsdist = True
 passenv =
     FORCE_COLOR


### PR DESCRIPTION
Cherry-picked from #8, I'm doing things progressively so it's reviewable.