### PR TITLE
A collection of minor improvements to tests

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Test with tox
         env:
           FORCE_COLOR: 1
-          PYTEST_CI_ARGS: --cov-report=xml --cov-report=html --junitxml=test_artifacts/test_report.xml --color=yes
+          PYTEST_CI_ARGS: --cov-report=xml --junitxml=test_artifacts/test_report.xml --color=yes
         run: tox ${{ matrix.python-version == '3.6' && '--skip-missing-interpreters=true' || '' }}
 
       - name: Upload coverage reports to Codecov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ module = [
 check_untyped_defs = true
 
 [tool.pytest.ini_options]
-addopts = "--verbose --cov-config=pyproject.toml"
+addopts = "--verbose --cov-config=pyproject.toml --cov-report=html"
 
 [tool.ruff]
 # ruff is less lenient than pylint and does not make any exceptions

--- a/tests/base_tester.py
+++ b/tests/base_tester.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from abc import ABC
+from pathlib import Path
 from pprint import pprint
 from typing import Any, Dict, List
 
@@ -19,6 +20,11 @@ import pylint_pytest.checkers.fixture
 
 # XXX: allow all file names
 pylint_pytest.checkers.fixture.FILE_NAME_PATTERNS = ("*",)
+
+
+def get_test_root_path() -> Path:
+    """Assumes ``base_tester.py`` is at ``<root>/tests``."""
+    return Path(__file__).parent
 
 
 class BasePytestTester(ABC):
@@ -41,7 +47,10 @@ class BasePytestTester(ABC):
         # pylint: disable-next=protected-access
         target_test_file = sys._getframe(1).f_code.co_name.replace("test_", "", 1)
         file_path = os.path.join(
-            os.getcwd(), "tests", "input", self.MSG_ID, target_test_file + ".py"
+            get_test_root_path(),
+            "input",
+            self.MSG_ID,
+            target_test_file + ".py",
         )
 
         with open(file_path) as fin:

--- a/tests/base_tester_test.py
+++ b/tests/base_tester_test.py
@@ -1,7 +1,12 @@
 import pytest
-from base_tester import BasePytestTester
+from base_tester import BasePytestTester, get_test_root_path
 
 # pylint: disable=unused-variable
+
+
+def test_get_test_root_path():
+    assert get_test_root_path().name == "tests"
+    assert (get_test_root_path() / "input").is_dir()
 
 
 def test_init_subclass_valid_msg_id():

--- a/tests/input/unused-argument/func_param_as_fixture_arg.py
+++ b/tests/input/unused-argument/func_param_as_fixture_arg.py
@@ -27,5 +27,8 @@ def test_nyfix(narg):  # unused-argument
 
 @pytest.mark.parametrize("arg", [1, 2, 3])
 def test_narg_is_used_nowhere(myfix, narg):
-    """A test function that uses the param through a fixture"""
+    """
+    A test function that does not use its param (``narg``):
+    Not itself, nor through a fixture (``myfix``).
+    """
     assert myfix


### PR DESCRIPTION
* Move `--cov-report=html` to `addopts`

  Non-`--cov` invocation is unaffected;
  "no reason" not to generate `--cov-report=html` in an untracked directory AFAIS.
* Fix tests running via PyCharm

  Would've been better to get the path via `requests.config.rootdir`,
  but it looks like a pain to inject the `requests` fixture here.
* Improve copy-paste docstring from 8756cc4627a66f150197519a2588512511f0c4f3