### PR TITLE
Support pylint v3 and drop v1  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [1.1.7] - 2023-12-04
+
+This is a small release to support additionally Pylint v3.
+It should be noted, however, that for linting, Pylint must be v3 or newer (due to backwards-incompatible changes).
+
+### Fixed
+
+* Support pylint v3 and drop v1 (https://github.com/pylint-dev/pylint-pytest/pull/27)
+
 ## [1.1.6] - 2023-11-20
 
 This is a small bugfix release.

--- a/pylint_pytest/checkers/__init__.py
+++ b/pylint_pytest/checkers/__init__.py
@@ -8,7 +8,8 @@ class BasePytestChecker(BaseChecker):
         # todo(maybe-remove): if we only support pylint>=3
         # Since https://github.com/pylint-dev/pylint/pull/8404, pylint does not need this
         # __implements__ pattern. keeping it for retro compatibility with pylint==2.x
-        from pylint.interfaces import IAstroidChecker  # pylint: disable=import-outside-toplevel
+        # pylint: disable=import-outside-toplevel,no-name-in-module
+        from pylint.interfaces import IAstroidChecker
 
         __implements__ = IAstroidChecker
 

--- a/pylint_pytest/checkers/__init__.py
+++ b/pylint_pytest/checkers/__init__.py
@@ -1,9 +1,11 @@
-import pylint
 from pylint.checkers import BaseChecker
+
+from pylint_pytest.utils import PYLINT_VERSION_MAJOR
 
 
 class BasePytestChecker(BaseChecker):
-    if int(pylint.version.split(".")[0]) < 3:
+    if PYLINT_VERSION_MAJOR < 3:
+        # todo(maybe-remove): if we only support pylint>=3
         # Since https://github.com/pylint-dev/pylint/pull/8404, pylint does not need this
         # __implements__ pattern. keeping it for retro compatibility with pylint==2.x
         from pylint.interfaces import IAstroidChecker  # pylint: disable=import-outside-toplevel

--- a/pylint_pytest/checkers/__init__.py
+++ b/pylint_pytest/checkers/__init__.py
@@ -1,5 +1,13 @@
+import pylint
 from pylint.checkers import BaseChecker
 
 
 class BasePytestChecker(BaseChecker):
+    if int(pylint.version.split(".")[0]) < 3:
+        # Since https://github.com/pylint-dev/pylint/pull/8404, pylint does not need this
+        # __implements__ pattern. keeping it for retro compatibility with pylint==2.x
+        from pylint.interfaces import IAstroidChecker  # pylint: disable=import-outside-toplevel
+
+        __implements__ = IAstroidChecker
+
     name = "pylint-pytest"

--- a/pylint_pytest/checkers/class_attr_loader.py
+++ b/pylint_pytest/checkers/class_attr_loader.py
@@ -1,14 +1,12 @@
 from typing import Optional, Set
 
 from astroid import Assign, Attribute, ClassDef, Name
-from pylint.interfaces import IAstroidChecker
 
 from ..utils import _can_use_fixture, _is_class_autouse_fixture
 from . import BasePytestChecker
 
 
 class ClassAttrLoader(BasePytestChecker):
-    __implements__ = IAstroidChecker
     msgs = {"E6400": ("", "pytest-class-attr-loader", "")}
 
     in_setup = False

--- a/pylint_pytest/checkers/fixture.py
+++ b/pylint_pytest/checkers/fixture.py
@@ -8,7 +8,6 @@ import astroid
 import pylint
 import pytest
 from pylint.checkers.variables import VariablesChecker
-from pylint.interfaces import IAstroidChecker
 
 from ..utils import (
     _can_use_fixture,
@@ -42,7 +41,6 @@ class FixtureCollector:
 
 
 class FixtureChecker(BasePytestChecker):
-    __implements__ = IAstroidChecker
     msgs = {
         "W6401": (
             "Using a deprecated @pytest.yield_fixture decorator",

--- a/pylint_pytest/checkers/fixture.py
+++ b/pylint_pytest/checkers/fixture.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Set, Tuple
 
 import astroid
-import pylint
 import pytest
 from pylint.checkers.variables import VariablesChecker
 
@@ -312,10 +311,4 @@ class FixtureChecker(BasePytestChecker):
         ):
             return
 
-        if int(pylint.__version__.split(".")[0]) >= 2:
-            FixtureChecker._original_add_message(
-                self, msgid, line, node, args, confidence, col_offset
-            )
-        else:
-            # python2 + pylint1.9 backward compatibility
-            FixtureChecker._original_add_message(self, msgid, line, node, args, confidence)
+        FixtureChecker._original_add_message(self, msgid, line, node, args, confidence, col_offset)

--- a/pylint_pytest/checkers/fixture.py
+++ b/pylint_pytest/checkers/fixture.py
@@ -232,7 +232,7 @@ class FixtureChecker(BasePytestChecker):
             for arg in node.args.args:
                 self._invoked_with_func_args.add(arg.name)
 
-    # pylint: disable=bad-staticmethod-argument,too-many-branches # The function itself is an if-return logic.
+    # pylint: disable=bad-staticmethod-argument # The function itself is an if-return logic.
     @staticmethod
     def patch_add_message(
         self, msgid, line=None, node=None, args=None, confidence=None, col_offset=None

--- a/pylint_pytest/utils.py
+++ b/pylint_pytest/utils.py
@@ -1,6 +1,9 @@
 import inspect
 
 import astroid
+import pylint
+
+PYLINT_VERSION_MAJOR = int(pylint.__version__.split(".")[0])
 
 
 def _is_pytest_mark_usefixtures(decorator):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,13 +123,11 @@ load-plugins= [
     "pylint.extensions.broad_try_clause",
     "pylint.extensions.check_elif",
     "pylint.extensions.code_style",
-    "pylint.extensions.comparetozero",
     "pylint.extensions.comparison_placement",
     "pylint.extensions.confusing_elif",
     # "pylint.extensions.consider_ternary_expression", # Not a pretty refactoring
     "pylint.extensions.docparams",
     "pylint.extensions.docstyle",
-    "pylint.extensions.emptystring",
     "pylint.extensions.eq_without_hash",
     "pylint.extensions.for_any_all",
     "pylint.extensions.mccabe",
@@ -174,4 +172,8 @@ output-format = "colorized"
 ignored-argument-names = "_.*"
 
 [tool.pylint."messages control"]
-enable = ["useless-suppression"]
+enable = [
+    "useless-suppression",
+    "use-implicit-booleaness-not-comparison-to-zero",
+    "use-implicit-booleaness-not-comparison-to-string",
+]

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(exclude=["tests*", "sandbox"]),
     install_requires=[
-        "pylint<3",
+        "pylint>=2",
         "pytest>=4.6",
     ],
     python_requires=">=3.6",

--- a/tests/base_tester.py
+++ b/tests/base_tester.py
@@ -3,7 +3,7 @@ import sys
 from abc import ABC
 from pathlib import Path
 from pprint import pprint
-from typing import Any, Dict, List
+from typing import List, Type
 
 import astroid
 from pylint.checkers import BaseChecker
@@ -23,10 +23,9 @@ def get_test_root_path() -> Path:
 
 class BasePytestTester(ABC):
     CHECKER_CLASS = BaseChecker
-    IMPACTED_CHECKER_CLASSES: List[BaseChecker] = []
+    IMPACTED_CHECKER_CLASSES: List[Type[BaseChecker]] = []
     MSG_ID: str
     msgs: List[MessageTest] = []
-    CONFIG: Dict[str, Any] = {}
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -72,14 +71,10 @@ class BasePytestTester(ABC):
         self.checker = self.CHECKER_CLASS(self.linter)
         self.impacted_checkers = []
 
-        for key, value in self.CONFIG.items():
-            setattr(self.checker.config, key, value)
         self.checker.open()
 
         for checker_class in self.IMPACTED_CHECKER_CLASSES:
             checker = checker_class(self.linter)
-            for key, value in self.CONFIG.items():
-                setattr(checker.config, key, value)
             checker.open()
             self.impacted_checkers.append(checker)
 

--- a/tests/base_tester.py
+++ b/tests/base_tester.py
@@ -6,15 +6,9 @@ from pprint import pprint
 from typing import Any, Dict, List
 
 import astroid
-from pylint.testutils import MessageTest, UnittestLinter
-
-try:
-    from pylint.utils import ASTWalker
-except ImportError:
-    # for pylint 1.9
-    from pylint.utils import PyLintASTWalker as ASTWalker
-
 from pylint.checkers import BaseChecker
+from pylint.testutils import MessageTest, UnittestLinter
+from pylint.utils import ASTWalker
 
 import pylint_pytest.checkers.fixture
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,4 +1,3 @@
-import pylint
 import pytest
 from base_tester import BasePytestTester
 from pylint.checkers.variables import VariablesChecker
@@ -18,9 +17,5 @@ class TestRegression(BasePytestTester):
         """catch a coding error when using fixture + if + inline import"""
         self.run_linter(enable_plugin)
 
-        if int(pylint.__version__.split(".")[0]) < 2:
-            # for some reason pylint 1.9.5 does not raise unused-import for inline import
-            self.verify_messages(1, msg_id="unused-import")
-        else:
-            self.verify_messages(2, msg_id="unused-import")
+        self.verify_messages(2, msg_id="unused-import")
         self.verify_messages(1, msg_id="redefined-outer-name")

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,11 @@
 [tox]
-envlist = py36,py37,py38,py39,py310,py311
+envlist =
+    py36-pylint2
+    py37-pylint2
+    py38-pylint{2,3}
+    py39-pylint{2,3}
+    py310-pylint{2,3}
+    py311-pylint{2,3}
 skipsdist = True
 passenv =
     FORCE_COLOR
@@ -8,6 +14,8 @@ passenv =
 deps =
     pytest
     pytest-cov
+    pylint2: pylint>2,<3
+    pylint3: pylint>3,<4
 commands =
     pip install --upgrade --editable .
     pytest --cov --cov-append {env:PYTEST_CI_ARGS:} {tty:--color=yes} {posargs:tests}


### PR DESCRIPTION
in pylint v3.0.0, there is https://github.com/pylint-dev/pylint/pull/8404, that breaks the current implementation of:
- ClassAttrLoader
- FixtureChecker

This fix is an attempt of supporting both pylint v2 and v3.

Other chances:
---

- remove the support of pylint v1 (was only possible in python 3.6. and [seems](https://github.com/pylint-dev/pylint-pytest/pull/27#discussion_r1411980104) to be broken) 
- use pylint v3 to check the source code

Fixes #12