### PR TITLE
fix fixture checker

### DIFF
--- a/pylint_pytest/checkers/fixture.py
+++ b/pylint_pytest/checkers/fixture.py
@@ -73,18 +73,18 @@ class FixtureChecker(BasePytestChecker):
     }
 
     # Store all fixtures discovered by pytest session
-    pytest_fixtures: FixtureDict = {}
+    _pytest_fixtures: FixtureDict = {}
     # Stores all used function arguments
-    invoked_with_func_args: set[str] = set()
+    _invoked_with_func_args: set[str] = set()
     # Stores all invoked fixtures through @pytest.mark.usefixture(...)
-    invoked_with_usefixtures: set[str] = set()
+    _invoked_with_usefixtures: set[str] = set()
 
     def close(self):
         """restore & reset class attr for testing"""
         # reset fixture info storage
-        FixtureChecker.pytest_fixtures = {}
-        FixtureChecker.invoked_with_func_args = set()
-        FixtureChecker.invoked_with_usefixtures = set()
+        FixtureChecker._pytest_fixtures = {}
+        FixtureChecker._invoked_with_func_args = set()
+        FixtureChecker._invoked_with_usefixtures = set()
 
     def visit_module(self, node):
         """
@@ -92,9 +92,9 @@ class FixtureChecker(BasePytestChecker):
         - invoke pytest session to collect available fixtures
         - create containers for the module to store args and fixtures
         """
-        FixtureChecker.pytest_fixtures = {}
-        FixtureChecker.invoked_with_func_args = set()
-        FixtureChecker.invoked_with_usefixtures = set()
+        FixtureChecker._pytest_fixtures = {}
+        FixtureChecker._invoked_with_func_args = set()
+        FixtureChecker._invoked_with_usefixtures = set()
 
         is_test_module = False
         for pattern in FILE_NAME_PATTERNS:
@@ -128,7 +128,7 @@ class FixtureChecker(BasePytestChecker):
                 # restore sys.path
                 sys.path = sys_path
 
-                FixtureChecker.pytest_fixtures = fixture_collector.fixtures
+                FixtureChecker._pytest_fixtures = fixture_collector.fixtures
 
                 legitimate_failure_paths = set(
                     collection_report.nodeid
@@ -212,11 +212,11 @@ class FixtureChecker(BasePytestChecker):
                     if _is_pytest_mark_usefixtures(decorator):
                         # save all visited fixtures
                         for arg in decorator.args:
-                            self.invoked_with_usefixtures.add(arg.value)
+                            self._invoked_with_usefixtures.add(arg.value)
                     if int(pytest.__version__.split(".")[0]) >= 3 and _is_pytest_fixture(
                         decorator, fixture=False
                     ):
                         # raise deprecated warning for @pytest.yield_fixture
                         self.add_message("deprecated-pytest-yield-fixture", node=node)
             for arg in node.args.args:
-                self.invoked_with_func_args.add(arg.name)
+                self._invoked_with_func_args.add(arg.name)

--- a/pylint_pytest/checkers/types.py
+++ b/pylint_pytest/checkers/types.py
@@ -1,15 +1,7 @@
 from __future__ import annotations
 
-import sys
-from pprint import pprint
 from typing import Any, Dict, List
 
 from _pytest.fixtures import FixtureDef
 
 FixtureDict = Dict[str, List[FixtureDef[Any]]]
-
-
-def replacement_add_message(*args, **kwargs):
-    print("Called un-initialized _original_add_message with:", file=sys.stderr)
-    pprint(args, sys.stderr)
-    pprint(kwargs, sys.stderr)

--- a/pylint_pytest/checkers/variables.py
+++ b/pylint_pytest/checkers/variables.py
@@ -13,6 +13,9 @@ from .fixture import FixtureChecker
 class CustomVariablesChecker(VariablesChecker):
     """Overrides the default VariablesChecker of pylint to discard unwanted warning messages"""
 
+    # pylint: disable=protected-access
+    # this class needs to access the fixture checker registries
+
     def add_message(
         self,
         msgid: str,
@@ -44,17 +47,17 @@ class CustomVariablesChecker(VariablesChecker):
                 node
                 and isinstance(node.parent, Module)
                 and node.parent.name.split(".")[-1] == "conftest"
-                and fixture_name in FixtureChecker.pytest_fixtures
+                and fixture_name in FixtureChecker._pytest_fixtures
             ):
                 return
 
             # imported fixture is referenced in test/fixture func
             elif (
-                fixture_name in FixtureChecker.invoked_with_func_args
-                and fixture_name in FixtureChecker.pytest_fixtures
+                fixture_name in FixtureChecker._invoked_with_func_args
+                and fixture_name in FixtureChecker._pytest_fixtures
             ):
                 if _is_same_module(
-                    fixtures=FixtureChecker.pytest_fixtures,
+                    fixtures=FixtureChecker._pytest_fixtures,
                     import_node=node,
                     fixture_name=fixture_name,
                 ):
@@ -62,11 +65,11 @@ class CustomVariablesChecker(VariablesChecker):
 
             # fixture is referenced in @pytest.mark.usefixtures
             elif (
-                fixture_name in FixtureChecker.invoked_with_usefixtures
-                and fixture_name in FixtureChecker.pytest_fixtures
+                fixture_name in FixtureChecker._invoked_with_usefixtures
+                and fixture_name in FixtureChecker._pytest_fixtures
             ):
                 if _is_same_module(
-                    fixtures=FixtureChecker.pytest_fixtures,
+                    fixtures=FixtureChecker._pytest_fixtures,
                     import_node=node,
                     fixture_name=fixture_name,
                 ):
@@ -79,15 +82,15 @@ class CustomVariablesChecker(VariablesChecker):
             and _can_use_fixture(node.parent.parent)
             and isinstance(node.parent, Arguments)
         ):
-            if node.name in FixtureChecker.pytest_fixtures:
+            if node.name in FixtureChecker._pytest_fixtures:
                 # argument is used as a fixture
                 return
 
             fixnames = (
-                arg.name for arg in node.parent.args if arg.name in FixtureChecker.pytest_fixtures
+                arg.name for arg in node.parent.args if arg.name in FixtureChecker._pytest_fixtures
             )
             for fixname in fixnames:
-                if node.name in FixtureChecker.pytest_fixtures[fixname][0].argnames:
+                if node.name in FixtureChecker._pytest_fixtures[fixname][0].argnames:
                     # argument is used by a fixture
                     return
 
@@ -97,7 +100,7 @@ class CustomVariablesChecker(VariablesChecker):
             and node
             and _can_use_fixture(node.parent.parent)
             and isinstance(node.parent, Arguments)
-            and node.name in FixtureChecker.pytest_fixtures
+            and node.name in FixtureChecker._pytest_fixtures
         ):
             return
 

--- a/pylint_pytest/checkers/variables.py
+++ b/pylint_pytest/checkers/variables.py
@@ -1,0 +1,104 @@
+from typing import Any, Optional
+
+from astroid import Arguments, Module
+from astroid.nodes.node_ng import NodeNG
+from pylint.checkers.variables import VariablesChecker
+from pylint.interfaces import Confidence
+
+from pylint_pytest.utils import _can_use_fixture, _is_same_module
+
+from .fixture import FixtureChecker
+
+
+class CustomVariablesChecker(VariablesChecker):
+    """Overrides the default VariablesChecker of pylint to discard unwanted warning messages"""
+
+    def add_message(
+        self,
+        msgid: str,
+        line: Optional[int] = None,
+        node: Optional[NodeNG] = None,
+        args: Any = None,
+        confidence: Confidence = None,
+        col_offset: Optional[int] = None,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
+    ) -> None:
+        """
+        - intercept and discard unwanted warning messages
+        """
+        # check W0611 unused-import
+        if msgid == "unused-import":
+            # actual attribute name is not passed as arg so...dirty hack
+            # message is usually in the form of '%s imported from %s (as %)'
+            message_tokens = args.split()
+            fixture_name = message_tokens[0]
+
+            # ignoring 'import %s' message
+            if message_tokens[0] == "import" and len(message_tokens) == 2:
+                pass
+
+            # fixture is defined in other modules and being imported to
+            # conftest for pytest magic
+            elif (
+                node
+                and isinstance(node.parent, Module)
+                and node.parent.name.split(".")[-1] == "conftest"
+                and fixture_name in FixtureChecker.pytest_fixtures
+            ):
+                return
+
+            # imported fixture is referenced in test/fixture func
+            elif (
+                fixture_name in FixtureChecker.invoked_with_func_args
+                and fixture_name in FixtureChecker.pytest_fixtures
+            ):
+                if _is_same_module(
+                    fixtures=FixtureChecker.pytest_fixtures,
+                    import_node=node,
+                    fixture_name=fixture_name,
+                ):
+                    return
+
+            # fixture is referenced in @pytest.mark.usefixtures
+            elif (
+                fixture_name in FixtureChecker.invoked_with_usefixtures
+                and fixture_name in FixtureChecker.pytest_fixtures
+            ):
+                if _is_same_module(
+                    fixtures=FixtureChecker.pytest_fixtures,
+                    import_node=node,
+                    fixture_name=fixture_name,
+                ):
+                    return
+
+        # check W0613 unused-argument
+        if (
+            msgid == "unused-argument"
+            and node
+            and _can_use_fixture(node.parent.parent)
+            and isinstance(node.parent, Arguments)
+        ):
+            if node.name in FixtureChecker.pytest_fixtures:
+                # argument is used as a fixture
+                return
+
+            fixnames = (
+                arg.name for arg in node.parent.args if arg.name in FixtureChecker.pytest_fixtures
+            )
+            for fixname in fixnames:
+                if node.name in FixtureChecker.pytest_fixtures[fixname][0].argnames:
+                    # argument is used by a fixture
+                    return
+
+        # check W0621 redefined-outer-name
+        if (
+            msgid == "redefined-outer-name"
+            and node
+            and _can_use_fixture(node.parent.parent)
+            and isinstance(node.parent, Arguments)
+            and node.name in FixtureChecker.pytest_fixtures
+        ):
+            return
+
+        super().add_message(msgid, line, node, args, confidence, col_offset)

--- a/tests/input/unused-import/mark_usesfixtures.py
+++ b/tests/input/unused-import/mark_usesfixtures.py
@@ -1,0 +1,8 @@
+import pytest
+
+from other_fixture import other_fixture_not_in_conftest
+
+
+@pytest.mark.usefixtures("other_fixture_not_in_conftest")
+def uses_imported_fixture_with_decorator():
+    assert True

--- a/tests/input/unused-import/module.py
+++ b/tests/input/unused-import/module.py
@@ -1,0 +1,5 @@
+import pytest
+
+
+def test_no_using_module():
+    assert True

--- a/tests/input/unused-import/other_fixture.py
+++ b/tests/input/unused-import/other_fixture.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture
+def other_fixture_not_in_conftest():
+    return True

--- a/tests/test_pylint_integration.py
+++ b/tests/test_pylint_integration.py
@@ -1,0 +1,29 @@
+"""
+The tests in this file shall detect any error related to actual execution of pylint, while the
+other test are more unit tests that focuses on the checkers behaviour.
+
+Notes:
+    Tests here are voluntarily minimalistic, the goal is not to test pylint, it is only checking
+    that pylint_pytest integrates just fine
+"""
+import subprocess
+
+
+def test_simple_process():
+    result = subprocess.run(
+        ["pylint", "--load-plugins", "pylint_pytest", "tests"],
+        capture_output=True,
+        check=False,
+    )
+    # then no error
+    assert not result.stderr
+
+
+def test_multi_process():
+    result = subprocess.run(
+        ["pylint", "--load-plugins", "pylint_pytest", "-j", "2", "tests"],
+        capture_output=True,
+        check=False,
+    )
+    # then no error
+    assert not result.stderr

--- a/tests/test_redefined_outer_name.py
+++ b/tests/test_redefined_outer_name.py
@@ -1,13 +1,13 @@
 import pytest
 from base_tester import BasePytestTester
-from pylint.checkers.variables import VariablesChecker
 
 from pylint_pytest.checkers.fixture import FixtureChecker
+from pylint_pytest.checkers.variables import CustomVariablesChecker
 
 
 class TestRedefinedOuterName(BasePytestTester):
     CHECKER_CLASS = FixtureChecker
-    IMPACTED_CHECKER_CLASSES = [VariablesChecker]
+    IMPACTED_CHECKER_CLASSES = [CustomVariablesChecker]
     MSG_ID = "redefined-outer-name"
 
     @pytest.mark.parametrize("enable_plugin", [True, False])

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,15 +1,15 @@
 import pytest
 from base_tester import BasePytestTester
-from pylint.checkers.variables import VariablesChecker
 
 from pylint_pytest.checkers.fixture import FixtureChecker
+from pylint_pytest.checkers.variables import CustomVariablesChecker
 
 
 class TestRegression(BasePytestTester):
     """Covering some behaviors that shouldn't get impacted by the plugin"""
 
     CHECKER_CLASS = FixtureChecker
-    IMPACTED_CHECKER_CLASSES = [VariablesChecker]
+    IMPACTED_CHECKER_CLASSES = [CustomVariablesChecker]
     MSG_ID = "regression"
 
     @pytest.mark.parametrize("enable_plugin", [True, False])

--- a/tests/test_unused_argument.py
+++ b/tests/test_unused_argument.py
@@ -1,13 +1,13 @@
 import pytest
 from base_tester import BasePytestTester
-from pylint.checkers.variables import VariablesChecker
 
 from pylint_pytest.checkers.fixture import FixtureChecker
+from pylint_pytest.checkers.variables import CustomVariablesChecker
 
 
 class TestUnusedArgument(BasePytestTester):
     CHECKER_CLASS = FixtureChecker
-    IMPACTED_CHECKER_CLASSES = [VariablesChecker]
+    IMPACTED_CHECKER_CLASSES = [CustomVariablesChecker]
     MSG_ID = "unused-argument"
 
     @pytest.mark.parametrize("enable_plugin", [True, False])

--- a/tests/test_unused_import.py
+++ b/tests/test_unused_import.py
@@ -1,13 +1,13 @@
 import pytest
 from base_tester import BasePytestTester
-from pylint.checkers.variables import VariablesChecker
 
 from pylint_pytest.checkers.fixture import FixtureChecker
+from pylint_pytest.checkers.variables import CustomVariablesChecker
 
 
 class TestUnusedImport(BasePytestTester):
     CHECKER_CLASS = FixtureChecker
-    IMPACTED_CHECKER_CLASSES = [VariablesChecker]
+    IMPACTED_CHECKER_CLASSES = [CustomVariablesChecker]
     MSG_ID = "unused-import"
 
     @pytest.mark.parametrize("enable_plugin", [True, False])

--- a/tests/test_unused_import.py
+++ b/tests/test_unused_import.py
@@ -40,3 +40,15 @@ class TestUnusedImport(BasePytestTester):
         for pytest to do its magic"""
         self.run_linter(enable_plugin)
         self.verify_messages(0 if enable_plugin else 1)
+
+    @pytest.mark.parametrize("enable_plugin", [True, False])
+    def test_module(self, enable_plugin):
+        """an unused module import shall still be an error"""
+        self.run_linter(enable_plugin)
+        self.verify_messages(1)
+
+    @pytest.mark.parametrize("enable_plugin", [True, False])
+    def test_mark_usesfixtures(self, enable_plugin):
+        """an unused module import shall still be an error"""
+        self.run_linter(enable_plugin)
+        self.verify_messages(0 if enable_plugin else 1)


### PR DESCRIPTION
the current implementation provokes recursion errors because of the
VariablesChecker.add_message patch not working properly.
This rework fix the issue by replacing the original variable checker by a subclass, without patch.
