### PR TITLE
define dev dependencies in the requirement file only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,14 +45,6 @@ dependencies = [
     "pytest>=4.6",
 ]
 
-[project.optional-dependencies]
-test = [
-    "pytest",
-    "pytest-cov",
-    # For linting purposes, only pylint>3 is supported
-    "pylint>=3",
-]
-
 [project.urls]
 Changelog = "https://github.com/pylint-dev/pylint-pytest/blob/master/CHANGELOG.md"
 Documentation = "https://github.com/pylint-dev/pylint-pytest#readme"

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,3 +1,6 @@
+# For linting purposes, only pylint>3 is supported
+pylint>=3
+
 # to handle dependencies
 pip-tools
 wheel

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -135,7 +135,9 @@ pre-commit==3.5.0 \
 pylint==3.0.2 \
     --hash=sha256:0d4c286ef6d2f66c8bfb527a7f8a629009e42c99707dec821a03e1b51a4c1496 \
     --hash=sha256:60ed5f3a9ff8b61839ff0348b3624ceeb9e6c2a92c514d81c9cc273da3b6bcda
-    # via pylint-pytest (pyproject.toml)
+    # via
+    #   -r requirements/dev.in
+    #   pylint-pytest (pyproject.toml)
 pyproject-hooks==1.0.0 \
     --hash=sha256:283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8 \
     --hash=sha256:f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5


### PR DESCRIPTION
we can mix pyproject.toml and dependency files, as the first one will be used while installing the package but the last one only serve in the CI.
Keeping the dev requirement in one place will simplify the requirement management